### PR TITLE
Update contact by email.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea/
+hubspot-clj.iml

--- a/src/hubspot/contact.clj
+++ b/src/hubspot/contact.clj
@@ -184,7 +184,7 @@
 
 (defn update-by-email!
   ([email params]
-   (update! email params {}))
+   (update-by-email! email params {}))
   ([email params opts]
    (h/post-req (format "contacts/v1/contact/email/%s/profile" email)
                (assoc-in opts [:params :properties] (params->properties params)))))

--- a/src/hubspot/contact.clj
+++ b/src/hubspot/contact.clj
@@ -182,6 +182,13 @@
         :ret (hs/async nil?))
 
 
+(defn update-by-email!
+  ([email params]
+   (update! email params {}))
+  ([email params opts]
+   (h/post-req (format "contacts/v1/contact/email/%s/profile" email)
+               (assoc-in opts [:params :properties] (params->properties params)))))
+
 
 (comment
   (def api-key "")


### PR DESCRIPTION
## Context
This is adding a function for the [hubspot endpoint to update contact by email](https://developers.hubspot.com/docs/methods/contacts/update_contact-by-email). I'm adding it to avoid having to make two requests to Hubspot to get a contact where we'd first get the ID by email, and then request the contact by id.

Related to https://github.com/starcity-properties/blueprints/pull/68

## Testing

Manual testing:
```clojure 
(comment
  (require '[hubspot.contact :as c])
  (require '[clojure.core.async :as async])
  (require '[hubspot.http :as h])

  (def api-key "demo")

  (do
    (let [p (c/fetch "andrew@gmail.com" {} {:api-key api-key})]
      (println "Old name: " (get-in p [:properties :firstname :value])))
    (let [new-name (str (gensym))
          _        (println "Set new name " new-name)
          _        (c/update-by-email! "andrew@gmail.com" {:firstname new-name} {:api-key api-key})
          p        (c/fetch "andrew@gmail.com" {} {:api-key api-key})]
      (println "New name: " (get-in p [:properties :firstname :value])))))
```
Output: 
```clojure 
Old name:  G__12201
Set new name  G__12217
New name:  G__12217
=> nil
```