### PR TITLE
Allow the addition of new contacts to a contact list

### DIFF
--- a/src/hubspot/contact.clj
+++ b/src/hubspot/contact.clj
@@ -146,6 +146,31 @@
         :ret (hs/async ::contact))
 
 
+(defn fetch-or-create!
+  "Fetch a contact by `email`, if one exists. If a contact with that email does
+  not exist, create one."
+  ([email]
+   (fetch-or-create! email {} {}))
+  ([email params]
+   (fetch-or-create! email params {}))
+  ([email params opts]
+   (if-not (s/valid? ::email email)
+     (throw (ex-info "Invalid email!" {:email email}))
+     (let [possible-contact (fetch email {} (assoc opts :throw-on-error? false))]
+       (println "\n\n========  possible contact is" possible-contact)
+       (if (some? (:error possible-contact))
+         (create! email params opts)
+         possible-contact)))))
+
+(s/fdef fetch-or-create!
+        :args (s/alt :unary   (s/cat :email ::email)
+                     :binary  (s/cat :email ::email
+                                     :params ::create-params)
+                     :ternary (s/cat :email ::email
+                                     :params ::create-params
+                                     :opts h/request-options?)))
+
+
 (defn search
   "Search contacts given a `query` string. Can optionally provide count, offset
   and property.

--- a/src/hubspot/contact.clj
+++ b/src/hubspot/contact.clj
@@ -157,7 +157,6 @@
    (if-not (s/valid? ::email email)
      (throw (ex-info "Invalid email!" {:email email}))
      (let [possible-contact (fetch email {} (assoc opts :throw-on-error? false))]
-       (println "\n\n========  possible contact is" possible-contact)
        (if (some? (:error possible-contact))
          (create! email params opts)
          possible-contact)))))

--- a/src/hubspot/contact_list.clj
+++ b/src/hubspot/contact_list.clj
@@ -31,6 +31,23 @@
   (s/keys :req-un [::properties ::vid ::profile-url]
           :opt-un [::identity-profiles ::form-submissions]))
 
+(s/def ::lists
+  (s/* map?))
+
+(s/def ::contact-list
+  (s/keys :req-un [::lists]))
+
+(s/def ::contact-lists
+  (s/+ ::contact-list))
+
+(s/def ::offset
+  integer?)
+
+(s/def ::count
+  integer?)
+
+(s/def ::fetch-params
+  (s/keys :opt-un [::offset ::count]))
 
 ;; ==============================================================================
 ;; HTTP API =====================================================================
@@ -58,3 +75,9 @@
    (fetch params {}))
   ([params opts]
    (h/get-req "contacts/v1/lists" (assoc opts :params params))))
+
+(s/fdef fetch
+        :args (s/alt :unary (s/cat :params ::fetch-params)
+                     :binary (s/cat :params ::fetch-params
+                                    :opts h/request-options?))
+        :ret (hs/async ::contact-lists))

--- a/src/hubspot/contact_list.clj
+++ b/src/hubspot/contact_list.clj
@@ -1,0 +1,60 @@
+(ns hubspot.contact-list
+  (:require [hubspot.http :as h]
+            [hubspot.spec :as hs]
+            [clojure.spec.alpha :as s]))
+
+
+;; ==============================================================================
+;; spec =========================================================================
+;; ==============================================================================
+
+
+(s/def ::list-id
+  integer?)
+
+(s/def ::vid
+  integer?)
+
+(s/def ::vids
+  (s/+ ::vid))
+
+(s/def ::email
+  hs/email?)
+
+(s/def ::emails
+  (s/+ ::email))
+
+(s/def ::add-contact-params
+  (s/keys :opt-un [::vids ::emails]))
+
+(s/def ::contact
+  (s/keys :req-un [::properties ::vid ::profile-url]
+          :opt-un [::identity-profiles ::form-submissions]))
+
+
+;; ==============================================================================
+;; HTTP API =====================================================================
+;; ==============================================================================
+
+
+(defn add-contact!
+  "Adds a contact (as identified by either a `:vid` or `:email` in `parmas`) to
+  the list with the provided `list-id`"
+  [list-id params opts]
+  (h/post-req
+   (format "contacts/v1/lists/%s/add" list-id)
+   (assoc opts :params params)))
+
+(s/fdef add-contact!
+        :args (s/cat :list-id ::list-id
+                     :params ::add-contact-params
+                     :opts h/request-options?)
+        :ret (hs/async ::contact))
+
+
+(defn fetch
+  "Fetch contact lists."
+  ([params]
+   (fetch params {}))
+  ([params opts]
+   (h/get-req "contacts/v1/lists" (assoc opts :params params))))


### PR DESCRIPTION
# Context

We're implementing a page on the website for an upcoming community, with the desire to allow site visitors to add themselves to that community's email waitlist directly. A community's waitlist is a Static Contact List within Hubspot.

Furthermore, we often encounter scenarios in which site visitors who have already been added as Hubspot contacts through some past action will enter their information again to add themselves to a new list (imagine, say, wanting to get on the list for several upcoming communities!). When we attempt to create a contact that already exists, the Hubspot API will produce an error and the contact will not be added to the list that they expect. 

Both of these needs are tightly related to each other, so this PR addresses them thusly:

## Changes

##### `hubspot.contact/fetch-or-create!`
`fetch-or-create!` uses the `fetch` and `create!` methods defined elsewhere in this namespace. Given an email address, it attempts to `fetch` a contact with that email. If a contact is found, this function returns that contact. If the contact is not found, the function will call `create!` and return the result.

##### New namespace: `hubspot.contact-list`
This namespace will collect functions for interacting with the [Hubspot Contact List API](https://developers.hubspot.com/docs/methods/lists/contact-lists-overview). At present, it offers two . methods: `fetch`, to get all the contact lists, and `add-contact!`, which will add a contact to one list.